### PR TITLE
fix simplegrep failure on Windows

### DIFF
--- a/examples/simplegrep/main.go
+++ b/examples/simplegrep/main.go
@@ -88,7 +88,7 @@ func main() {
 	if !*flagNoColor {
 		stat, _ := os.Stdout.Stat()
 
-		if stat.Mode()&os.ModeType != 0 {
+		if stat != nil && stat.Mode()&os.ModeType != 0 {
 			theme = highlight
 		}
 	}


### PR DESCRIPTION
The error:

```
panic: runtime error: invalid memory address or nil pointer dereference
... simplegrep/main.go:91
```

was caused by `os.Stdout.Stat()` returning nil and error.