### PR TITLE
Correct the link to the hyperscan project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# gohs [![traivs](https://travis-ci.org/flier/gohs.svg)](https://travis-ci.org/flier/gohs)
-GoLang Binding of HyperScan https://01.org/hyperscan
+# gohs [![travis](https://travis-ci.org/flier/gohs.svg)](https://travis-ci.org/flier/gohs)
+
+GoLang Binding of Intel's HyperScan regex matching library: https://www.hyperscan.io/
 
 [API Reference](https://godoc.org/github.com/flier/gohs/hyperscan)
 


### PR DESCRIPTION
It would seem that the Hyperscan's original link has moved. The      
final version of the original source can be found at the internet   
archive: https://web.archive.org/web/20171118201103/01.org/hyperscan

This commit points to the most recent Hyperscan project page for
folks wanting to learn more about that.