### PR TITLE
Compile flags are case sensitive

### DIFF
--- a/hyperscan/compile.go
+++ b/hyperscan/compile.go
@@ -66,7 +66,7 @@ func ParsePattern(s string) (*Pattern, error) {
 	} else {
 		p.Expression = Expression(s[1:n])
 
-		flags, err := ParseCompileFlag(strings.ToLower(s[n+1:]))
+		flags, err := ParseCompileFlag(s[n+1:])
 
 		if err != nil {
 			return nil, errors.New("invalid pattern, " + err.Error())

--- a/hyperscan/compile_v5_test.go
+++ b/hyperscan/compile_v5_test.go
@@ -1,0 +1,32 @@
+// +build !hyperscan_v4
+
+package hyperscan
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDatabaseBuilderV5(t *testing.T) {
+	Convey("Given a DatabaseBuilder (v5)", t, func() {
+		b := DatabaseBuilder{}
+		Convey("When build with some combination expression", func() {
+			db, err := b.AddExpressions("101:/abc/Q", "102:/def/Q", "/(101&102)/Co").Build()
+
+			So(err, ShouldBeNil)
+			So(db, ShouldNotBeNil)
+
+			info, err := db.Info()
+
+			So(err, ShouldBeNil)
+
+			mode, err := info.Mode()
+
+			So(err, ShouldBeNil)
+			So(mode, ShouldEqual, BlockMode)
+
+			So(db.Close(), ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
When trying to use an expression with the new features in v5 I noticed that the new compile flags were converted to lowercase. This fixes it and adds a test for combination expressions.