### PR TITLE
Fix #16: HS_FLAG_ALLOWEMPTY empty string

### DIFF
--- a/hyperscan/internal.go
+++ b/hyperscan/internal.go
@@ -917,13 +917,15 @@ func hsMatchEventCallback(id C.uint, from, to C.ulonglong, flags C.uint, data un
 }
 
 func hsScan(db hsDatabase, data []byte, flags ScanFlag, scratch hsScratch, onEvent hsMatchEventHandler, context interface{}) error {
+	datalen := len(data)
+	datatoscan := data
 	if len(data) == 0 {
-		return HsError(C.HS_INVALID)
+		datatoscan = []byte{0}
 	}
 
 	ctxt := &hsMatchEventContext{onEvent, context}
 
-	ret := C.hs_scan_cgo(db, (*C.char)(unsafe.Pointer(&data[0])), C.uint(len(data)),
+	ret := C.hs_scan_cgo(db, (*C.char)(unsafe.Pointer(&datatoscan[0])), C.uint(datalen),
 		C.uint(flags), scratch, C.uintptr_t(uintptr(unsafe.Pointer(ctxt))))
 
 	runtime.KeepAlive(data)
@@ -945,12 +947,13 @@ func hsScanVector(db hsDatabase, data [][]byte, flags ScanFlag, scratch hsScratc
 	clength := make([]C.uint, len(data))
 
 	for i, d := range data {
+		datalen := len(d)
 		if len(d) == 0 {
-			return HsError(C.HS_INVALID)
+			d = []byte{0}
 		}
 
 		cdata[i] = uintptr(unsafe.Pointer(&d[0]))
-		clength[i] = C.uint(len(d))
+		clength[i] = C.uint(datalen)
 	}
 
 	ctxt := &hsMatchEventContext{onEvent, context}

--- a/hyperscan/internal_test.go
+++ b/hyperscan/internal_test.go
@@ -292,6 +292,56 @@ func TestDatabase(t *testing.T) {
 	})
 }
 
+func TestALLOWEMPTY(t *testing.T) {
+
+	Convey("Test block", t, func() {
+		platform, err := hsPopulatePlatform()
+
+		So(platform, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		db, err := hsCompile("", AllowEmpty, BlockMode, platform)
+
+		So(db, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		s, err := hsAllocScratch(db)
+
+		So(s, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		h := &matchRecorder{}
+
+		So(hsScan(db, []byte(""), 0, s, h.Handle, nil), ShouldBeNil)
+		So(h.matched, ShouldNotBeEmpty)
+
+		So(hsFreeDatabase(db), ShouldBeNil)
+	})
+
+	Convey("Test Vector", t, func() {
+		platform, err := hsPopulatePlatform()
+
+		So(platform, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		db, err := hsCompile("", AllowEmpty, VectoredMode, platform)
+
+		So(db, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		s, err := hsAllocScratch(db)
+
+		So(s, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		h := &matchRecorder{}
+
+		So(hsScanVector(db, [][]byte{[]byte(""), []byte("")}, 0, s, h.Handle, nil), ShouldBeNil)
+		So(h.matched, ShouldNotBeEmpty)
+
+		So(hsFreeDatabase(db), ShouldBeNil)
+	})
+
+}
+
 func TestCompileAPI(t *testing.T) {
 	Convey("Given a host platform", t, func() {
 		platform, err := hsPopulatePlatform()


### PR DESCRIPTION
When passing empty buffer. fix by replace it with a new buffer.