### PR TITLE
Address intermittent crash on go 1.14 due to invalid pointer-passing and stack resizing

### DIFF
--- a/hyperscan/internal.go
+++ b/hyperscan/internal.go
@@ -928,8 +928,8 @@ func hsMatchEventCallback(id C.uint, from, to C.ulonglong, flags C.uint, data un
 	// is resilient to unexpected stack resizing
 	//
 	mux.Lock()
-        ctxt := memMap[data]
-        mux.Unlock()
+	ctxt := memMap[data]
+	mux.Unlock()
 
 	if err := ctxt.handler(uint(id), uint64(from), uint64(to), uint(flags), ctxt.context); err != nil {
 		return -1
@@ -963,16 +963,16 @@ func hsScan(db hsDatabase, data []byte, flags ScanFlag, scratch hsScratch, onEve
 	//      points does not contain any Go pointers.
 	//
 	ptr := unsafe.Pointer(ctxt)
-        mux.Lock()
-        memMap[ptr] = ctxt
-        mux.Unlock()
-        defer func() {
-                mux.Lock()
-                delete(memMap,ptr)
-                mux.Unlock()
-        }()
-        ret := C.hs_scan_cgo(db, (*C.char)(unsafe.Pointer(data_hdr.Data)), C.uint(data_hdr.Len),
-                C.uint(flags), scratch, C.uintptr_t(uintptr(ptr)))
+	mux.Lock()
+	memMap[ptr] = ctxt
+	mux.Unlock()
+	defer func() {
+		mux.Lock()
+		delete(memMap,ptr)
+		mux.Unlock()
+	}()
+	ret := C.hs_scan_cgo(db, (*C.char)(unsafe.Pointer(data_hdr.Data)), C.uint(data_hdr.Len),
+		C.uint(flags), scratch, C.uintptr_t(uintptr(ptr)))
 
 	runtime.KeepAlive(data)
 	runtime.KeepAlive(ctxt)


### PR DESCRIPTION
Addresses: https://github.com/flier/gohs/issues/20

Per https://golang.org/cmd/cgo/: 
```A Go function called by C code may not return a Go pointer (which implies that it may not return a string, slice, channel, and so forth). A Go function called by C code may take C pointers as arguments, and it may store non-pointer or C pointer data through those pointers, but it may not store a Go pointer in memory pointed to by a C pointer. A Go function called by C code may take a Go pointer as an argument, but it must preserve the property that the Go memory to which it points does not contain any Go pointers.```

This results in semi-reproducible crashes per the issue above where SEGV's are encountered at runtime due to an invalidated context pointer, which was cast to a c-pointer as an intermediary, being used to cast to a go object.

This update keeps the go-pointers in a go-based map, hashed by original address, and uses the c-pointer as an "original address".

Reproduced on MacOS 10.15.6 w/go version go1.14.3 darwin/amd64

