### PR TITLE
wg.Add(1) should be done outside the go function.

### DIFF
--- a/examples/simplegrep/main.go
+++ b/examples/simplegrep/main.go
@@ -149,10 +149,9 @@ func main() {
 		for _, filename := range filenames {
 			filename := filename
 
-			go func() {
-				wg.Add(1)
-				defer wg.Done()
+			wg.Add(1)
 
+			go func() {
 				scratch, release := scratchAlloc()
 				defer release()
 
@@ -188,6 +187,8 @@ func main() {
 					os.Exit(-1)
 				}
 				fmt.Fprint(os.Stdout, buf.String())
+
+				wg.Done()
 			}()
 		}
 	}


### PR DESCRIPTION
The Go implementation of simplegrep didn't work. I fixed it by moving the wg.Add() call which should be outside of the go routine (as per the waitgroup docs). It was a finicky one to catch as the program would just complete with 0 files scanned.