### PR TITLE
Add handle implementation that does not depend on cgo.Handle

### DIFF
--- a/internal/handle/go1_17.go
+++ b/internal/handle/go1_17.go
@@ -1,5 +1,5 @@
-//go:build go1.17
-// +build go1.17
+//go:build go1.17 && !go1.21
+// +build go1.17,!go1.21
 
 package handle
 

--- a/internal/handle/go1_21.go
+++ b/internal/handle/go1_21.go
@@ -1,0 +1,60 @@
+//go:build go1.21
+// +build go1.21
+
+package handle
+
+import "C"
+import (
+	"runtime"
+)
+
+// GoHandle provides a way to pass values that contain Go pointers (pointers to memory allocated by
+// Go) between Go and C without breaking the cgo pointer passing rules. It uses the Pinner feature
+// in the runtime instead of the cgo.Handle type in the cgo runtime to avoid lock contention due to
+// the use of sync.Map in the cgo implementation.
+type GoHandle struct {
+	pinner *runtime.Pinner
+	value  *any
+}
+
+// Value gets the handle value.
+func (h *GoHandle) Value() any {
+	return *h.value
+}
+
+// Set sets the handle value.
+func (h *GoHandle) Set(v any) {
+	h.Delete()
+	pinner := &runtime.Pinner{}
+	pinner.Pin(pinner)
+	pinner.Pin(&v)
+	h.pinner = pinner
+	h.value = &v
+}
+
+// Delete stops the Go runtime tracking of the referred Go value.
+//
+// If the Go runtime does not manage the GoHandle storage, it cannot detect when the referred value
+// becomes inaccessible. Before deallocating the GoHandle is necessary to close it so to prevent
+// memory leaks.
+func (h *GoHandle) Delete() {
+	if h.pinner != nil {
+		h.pinner.Unpin()
+		h.pinner = nil
+		h.value = nil
+	}
+}
+
+// NewHandle creates a new handle and pins it to the given value.
+func NewHandle(v any) *GoHandle {
+	h := &GoHandle{}
+	h.Set(v)
+	return h
+}
+
+// Handle provides a way to pass values that contain Go pointers (pointers to memory allocated by Go)
+// between Go and C without breaking the cgo pointer passing rules.
+type Handle = GoHandle
+
+// New returns a handle for a given value.
+var New = NewHandle


### PR DESCRIPTION
cgo.Handle uses a sync.Map, which leads to large amounts of lock contention in highly concurrent use cases. Since 1.21, the Pinner object in the runtime provides similar functionality.

This change provides a new Pinner-based implementation of the Handle type to avoid lock-contention altogether.