### PR TITLE
Add handle implementation that does not depend on cgo.Handle

### DIFF
--- a/internal/ch/runtime.go
+++ b/internal/ch/runtime.go
@@ -138,7 +138,7 @@ func Scan(db Database, data []byte, flags ScanFlag, scratch Scratch,
 		scratch,
 		C.ch_match_event_handler(C.matchEventCallback),
 		C.ch_error_event_handler(C.errorEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	// Ensure go data is alive before the C function returns
 	runtime.KeepAlive(data)

--- a/internal/handle/go1_15.go
+++ b/internal/handle/go1_15.go
@@ -3,6 +3,8 @@
 
 package handle
 
+import "unsafe"
+
 // Delete invalidates a handle. This method should only be called once
 // the program no longer needs to pass the handle to C and the C code
 // no longer has a copy of the handle value.
@@ -13,4 +15,9 @@ func (h Handle) Delete() {
 	if !ok {
 		panic("runtime/cgo: misuse of an invalid Handle")
 	}
+}
+
+// Pointer returns an unsafe.Pointer to the handle.
+func Pointer(h Handle) unsafe.Pointer {
+	return unsafe.Pointer(&h)
 }

--- a/internal/handle/go1_17.go
+++ b/internal/handle/go1_17.go
@@ -1,10 +1,13 @@
-//go:build go1.17
-// +build go1.17
+//go:build go1.17 && !go1.21
+// +build go1.17,!go1.21
 
 package handle
 
 import "C"
-import "runtime/cgo"
+import (
+	"runtime/cgo"
+	"unsafe"
+)
 
 // Handle provides a way to pass values that contain Go pointers (pointers to memory allocated by Go)
 // between Go and C without breaking the cgo pointer passing rules.
@@ -12,3 +15,8 @@ type Handle = cgo.Handle
 
 // New returns a handle for a given value.
 var New = cgo.NewHandle
+
+// Pointer returns an unsafe.Pointer to the handle.
+func Pointer(h Handle) unsafe.Pointer {
+	return unsafe.Pointer(&h)
+}

--- a/internal/handle/go1_21.go
+++ b/internal/handle/go1_21.go
@@ -1,0 +1,66 @@
+//go:build go1.21
+// +build go1.21
+
+package handle
+
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+// GoHandle provides a way to pass values that contain Go pointers (pointers to memory allocated by
+// Go) between Go and C without breaking the cgo pointer passing rules. It uses the Pinner feature
+// in the runtime instead of the cgo.Handle type in the cgo runtime to avoid lock contention due to
+// the use of sync.Map in the cgo implementation.
+type GoHandle struct {
+	pinner *runtime.Pinner
+	value  *any
+}
+
+// Value gets the handle value.
+func (h *GoHandle) Value() any {
+	return *h.value
+}
+
+// Set sets the handle value.
+func (h *GoHandle) Set(v any) {
+	h.Delete()
+	pinner := &runtime.Pinner{}
+	pinner.Pin(pinner)
+	pinner.Pin(&v)
+	h.pinner = pinner
+	h.value = &v
+}
+
+// Delete stops the Go runtime tracking of the referred Go value.
+//
+// If the Go runtime does not manage the GoHandle storage, it cannot detect when the referred value
+// becomes inaccessible. Before deallocating the GoHandle is necessary to close it so to prevent
+// memory leaks.
+func (h *GoHandle) Delete() {
+	if h.pinner != nil {
+		h.pinner.Unpin()
+		h.pinner = nil
+		h.value = nil
+	}
+}
+
+// NewHandle creates a new handle and pins it to the given value.
+func NewHandle(v any) *GoHandle {
+	h := &GoHandle{}
+	h.Set(v)
+	return h
+}
+
+// Handle provides a way to pass values that contain Go pointers (pointers to memory allocated by Go)
+// between Go and C without breaking the cgo pointer passing rules.
+type Handle = GoHandle
+
+// New returns a handle for a given value.
+var New = NewHandle
+
+// Pointer returns an unsafe.Pointer to the handle.
+func Pointer(h *Handle) unsafe.Pointer {
+	return unsafe.Pointer(h)
+}

--- a/internal/handle/go1_9.go
+++ b/internal/handle/go1_9.go
@@ -3,6 +3,8 @@
 
 package handle
 
+import "unsafe"
+
 // Delete invalidates a handle. This method should only be called once
 // the program no longer needs to pass the handle to C and the C code
 // no longer has a copy of the handle value.
@@ -15,4 +17,9 @@ func (h Handle) Delete() {
 	} else {
 		panic("runtime/cgo: misuse of an invalid Handle")
 	}
+}
+
+// Pointer returns an unsafe.Pointer to the handle.
+func Pointer(h Handle) unsafe.Pointer {
+	return unsafe.Pointer(&h)
 }

--- a/internal/handle/handle.go
+++ b/internal/handle/handle.go
@@ -9,6 +9,7 @@ package handle
 import (
 	"sync"
 	"sync/atomic"
+	"unsafe"
 )
 
 // Handle provides a way to pass values that contain Go pointers
@@ -97,3 +98,8 @@ var (
 	handles   = sync.Map{} // map[Handle]interface{}
 	handleIdx uintptr      // atomic
 )
+
+// Pointer returns an unsafe.Pointer to the handle.
+func Pointer(h Handle) unsafe.Pointer {
+	return unsafe.Pointer(&h)
+}

--- a/internal/hs/runtime.go
+++ b/internal/hs/runtime.go
@@ -69,7 +69,7 @@ func Scan(db Database, data []byte, flags ScanFlag, s Scratch, cb MatchEventHand
 		C.uint(flags),
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	// Ensure go data is alive before the C function returns
 	runtime.KeepAlive(data)
@@ -113,7 +113,7 @@ func ScanVector(db Database, data [][]byte, flags ScanFlag, s Scratch, cb MatchE
 		C.uint(flags),
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	// Ensure go data is alive before the C function returns
 	runtime.KeepAlive(data)

--- a/internal/hs/stream.go
+++ b/internal/hs/stream.go
@@ -49,7 +49,7 @@ func ScanStream(stream Stream, data []byte, flags ScanFlag, s Scratch, cb MatchE
 		C.uint(flags),
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	// Ensure go data is alive before the C function returns
 	runtime.KeepAlive(data)
@@ -72,7 +72,7 @@ func CloseStream(stream Stream, s Scratch, cb MatchEventHandler, ctx interface{}
 	ret := C.hs_close_stream(stream,
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	if ret != C.HS_SUCCESS {
 		return Error(ret)
@@ -89,7 +89,7 @@ func ResetStream(stream Stream, flags ScanFlag, s Scratch, cb MatchEventHandler,
 		C.uint(flags),
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	if ret != C.HS_SUCCESS {
 		return Error(ret)
@@ -116,7 +116,7 @@ func ResetAndCopyStream(to, from Stream, s Scratch, cb MatchEventHandler, ctx in
 		from,
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	if ret != C.HS_SUCCESS {
 		return Error(ret)
@@ -164,7 +164,7 @@ func ResetAndExpandStream(stream Stream, buf []byte, s Scratch, cb MatchEventHan
 		C.size_t(len(buf)),
 		s,
 		C.match_event_handler(C.hsMatchEventCallback),
-		unsafe.Pointer(&h))
+		handle.Pointer(h))
 
 	runtime.KeepAlive(buf)
 


### PR DESCRIPTION
cgo.Handle uses a sync.Map, which leads to large amounts of lock contention in highly concurrent use cases. Since 1.21, the Pinner object in the runtime provides similar functionality.

This change provides a new Pinner-based implementation of the Handle type to avoid lock-contention altogether.