### PR TITLE
Fix two compilation errors on i686-w64-mingw32

### DIFF
--- a/internal/ch/compile.go
+++ b/internal/ch/compile.go
@@ -144,13 +144,13 @@ func CompileExtMulti(p Patterns, mode CompileMode, info *hs.PlatformInfo,
 	patterns := p.Patterns()
 
 	cexprs := (**C.char)(C.calloc(C.size_t(len(patterns)), C.size_t(unsafe.Sizeof(uintptr(0)))))
-	exprs := (*[1 << 30]*C.char)(unsafe.Pointer(cexprs))[:len(patterns):len(patterns)]
+	exprs := unsafe.Slice(cexprs, len(patterns))
 
 	cflags := (*C.uint)(C.calloc(C.size_t(len(patterns)), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	flags := (*[1 << 30]C.uint)(unsafe.Pointer(cflags))[:len(patterns):len(patterns)]
+	flags := unsafe.Slice(cflags, len(patterns))
 
 	cids := (*C.uint)(C.calloc(C.size_t(len(patterns)), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	ids := (*[1 << 30]C.uint)(unsafe.Pointer(cids))[:len(patterns):len(patterns)]
+	ids := unsafe.Slice(cids, len(patterns))
 
 	for i, pattern := range patterns {
 		exprs[i] = C.CString(pattern.Expression)

--- a/internal/hs/compile.go
+++ b/internal/hs/compile.go
@@ -404,16 +404,16 @@ func CompileMulti(input Patterns, mode ModeFlag, info *PlatformInfo) (Database, 
 	count := len(patterns)
 
 	cexprs := (**C.char)(C.calloc(C.size_t(count), C.size_t(unsafe.Sizeof(uintptr(0)))))
-	exprs := (*[1 << 30]*C.char)(unsafe.Pointer(cexprs))[:count:count]
+	exprs := unsafe.Slice(cexprs, count)
 
 	cflags := (*C.uint)(C.calloc(C.size_t(count), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	flags := (*[1 << 30]C.uint)(unsafe.Pointer(cflags))[:count:count]
+	flags := unsafe.Slice(cflags, count)
 
 	cids := (*C.uint)(C.calloc(C.size_t(count), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	ids := (*[1 << 30]C.uint)(unsafe.Pointer(cids))[:count:count]
+	ids := unsafe.Slice(cids, count)
 
 	cexts := (**C.hs_expr_ext_t)(C.calloc(C.size_t(count), C.size_t(unsafe.Sizeof(uintptr(0)))))
-	exts := (*[1 << 30]*C.hs_expr_ext_t)(unsafe.Pointer(cexts))[:count:count]
+	exts := unsafe.Slice(cexts, count)
 
 	for i, pattern := range patterns {
 		exprs[i] = C.CString(pattern.Expr)

--- a/internal/hs/compile_v52.go
+++ b/internal/hs/compile_v52.go
@@ -71,16 +71,16 @@ func CompileLitMulti(input Literals, mode ModeFlag, info *PlatformInfo) (Databas
 	count := len(literals)
 
 	cexprs := (**C.char)(C.calloc(C.size_t(len(literals)), C.size_t(unsafe.Sizeof(uintptr(0)))))
-	exprs := (*[1 << 30]*C.char)(unsafe.Pointer(cexprs))[:len(literals):len(literals)]
+	exprs := unsafe.Slice(cexprs, len(literals))
 
 	clens := (*C.size_t)(C.calloc(C.size_t(len(literals)), C.size_t(unsafe.Sizeof(uintptr(0)))))
-	lens := (*[1 << 30]C.size_t)(unsafe.Pointer(clens))[:len(literals):len(literals)]
+	lens := unsafe.Slice(clens, len(literals))
 
 	cflags := (*C.uint)(C.calloc(C.size_t(len(literals)), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	flags := (*[1 << 30]C.uint)(unsafe.Pointer(cflags))[:len(literals):len(literals)]
+	flags := unsafe.Slice(cflags, len(literals))
 
 	cids := (*C.uint)(C.calloc(C.size_t(len(literals)), C.size_t(unsafe.Sizeof(C.uint(0)))))
-	ids := (*[1 << 30]C.uint)(unsafe.Pointer(cids))[:len(literals):len(literals)]
+	ids := unsafe.Slice(cids, len(literals))
 
 	for i, lit := range literals {
 		exprs[i] = C.CString(lit.Expr)

--- a/internal/hs/compile_v52.go
+++ b/internal/hs/compile_v52.go
@@ -37,7 +37,7 @@ func CompileLit(expression string, flags CompileFlag, mode ModeFlag, info *Platf
 
 	defer C.free(unsafe.Pointer(expr))
 
-	ret := C.hs_compile_lit(expr, C.uint(flags), C.ulong(len(expression)), C.uint(mode), platform, &db, &err)
+	ret := C.hs_compile_lit(expr, C.uint(flags), C.size_t(len(expression)), C.uint(mode), platform, &db, &err)
 
 	if err != nil {
 		defer C.hs_free_compile_error(err)


### PR DESCRIPTION
With these two fixes, I managed to build `simplegrep.exe` for Windows using i686-w64-mingw32 (cross-compilation from Linux).